### PR TITLE
[TH2-2739] Update sailfish-core version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ The `th2_check1_active_tasks_number` metric separate rules with label `rule_type
 + Migrated `sailfish-utils` version from `3.9.1` to `3.10.2`
   + Fixed conversion of `null` values
 + Corrected verification entry when the `null` value and string `"null"` looked the same for the expected value
++ Migrated `sailfish-core` version to `3.2.1752`
+  + Fix incorrect matching in repeating groups with reordered messages
 
 ### 3.8.0
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 ext {
     sharedDir           = file("${project.rootDir}/shared")
-    sailfishVersion     = '3.2.1050'
+    sailfishVersion     = '3.2.1752'
 }
 
 group = 'com.exactpro.th2'


### PR DESCRIPTION
It contains fixes for incorrect matching inside repeating group when the elements are reordered and the filter has less elements than the actual message